### PR TITLE
Fix bulk sync to use UTC time instead of scheduling sync +TZ hours in future

### DIFF
--- a/includes/class-shippit-order.php
+++ b/includes/class-shippit-order.php
@@ -274,7 +274,12 @@ class Mamis_Shippit_Order
         }
 
         // Create the schedule for the orders to sync
-        wp_schedule_single_event(current_time('timestamp'), 'syncOrders');
+        // WP expects UTC time -- not local time 
+        wp_schedule_single_event(time(), 'syncOrders');
+
+        $logger = wc_get_logger();
+        $loggerContext = array( 'source' => 'shippit' );
+        $logger->info('Scheduled single event', $loggerContext );
 
         return add_query_arg(array('shippit_sync' => '2'), $redirectTo);
     }


### PR DESCRIPTION
When bulk syncing orders, the sync task was being created in Local Time not UTC as WP_Cron expects. This results in the task being +TZ hours out.